### PR TITLE
Fix ed25519PkToCurve25519 jvm and native implementations

### DIFF
--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -24,14 +24,13 @@ object Versions {
     val dokkaPlugin = "1.5.0"
     val taskTreePlugin = "1.5"
     val kotlinBigNumVersion = "0.2.8"
-    val jna = "5.7.0"
+    val jna = "5.10.0"
     val kotlinPoet = "1.6.0"
     val sampleLibsodiumBindings = "0.8.5-SNAPSHOT"
     val ktor = "1.3.2"
     val timber = "4.7.1"
     val kodeinVersion = "7.1.0"
-
-    val resourceLoader = "2.0.1"
+    val resourceLoader = "2.0.2"
 
 
 

--- a/multiplatform-crypto-libsodium-bindings/src/jvmMain/kotlin/com/ionspin/kotlin/crypto/signature/SignatureJvm.kt
+++ b/multiplatform-crypto-libsodium-bindings/src/jvmMain/kotlin/com/ionspin/kotlin/crypto/signature/SignatureJvm.kt
@@ -159,7 +159,7 @@ actual object Signature {
      */
     actual fun ed25519PkToCurve25519(ed25519PublicKey: UByteArray) : UByteArray {
         val x25519PublicKey = UByteArray(crypto_scalarmult_curve25519_BYTES)
-        sodiumJna.crypto_sign_ed25519_sk_to_curve25519(
+        sodiumJna.crypto_sign_ed25519_pk_to_curve25519(
             x25519PublicKey.asByteArray(),
             ed25519PublicKey.asByteArray()
         )

--- a/multiplatform-crypto-libsodium-bindings/src/nativeMain/kotlin/com/ionspin/kotlin/crypto/signature/Signature.kt
+++ b/multiplatform-crypto-libsodium-bindings/src/nativeMain/kotlin/com/ionspin/kotlin/crypto/signature/Signature.kt
@@ -207,7 +207,7 @@ actual object Signature {
         val x25519PublicKey = UByteArray(crypto_scalarmult_curve25519_BYTES)
         val x25519PublicKeyPinned = x25519PublicKey.pin()
         val ed25519PublicKeyPinned = ed25519PublicKey.pin()
-        crypto_sign_ed25519_sk_to_curve25519(
+        crypto_sign_ed25519_pk_to_curve25519(
             x25519PublicKeyPinned.toPtr(),
             ed25519PublicKeyPinned.toPtr()
         )


### PR DESCRIPTION
ed25519PkToCurve25519 was calling libsodium sk_to_curve in both native and jvm platforms. Fixed so it calls appropriate pk_to_curve. Fixes #20