### PR TITLE
JS module fixes

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -28,7 +28,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.20-RC2")
     implementation("com.android.tools.build:gradle:4.0.2")
 }
 

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -16,7 +16,7 @@
 
 object Versions {
     val kotlinCoroutines = "1.6.0-native-mt"
-    val kotlin = "1.6.10"
+    val kotlin = "1.6.20-RC2"
     val kotlinSerialization = "1.3.2"
     val kotlinSerializationPlugin = kotlin
     val atomicfu = "0.14.3-M2-2-SNAPSHOT" //NOTE: my linux arm32 and arm64 build

--- a/multiplatform-crypto-libsodium-bindings/src/jsMain/kotlin/com/ionspin/kotlin/crypto/JsSodiumInterface.kt
+++ b/multiplatform-crypto-libsodium-bindings/src/jsMain/kotlin/com/ionspin/kotlin/crypto/JsSodiumInterface.kt
@@ -9,10 +9,10 @@ import org.khronos.webgl.Uint8Array
  * ugljesa.jovanovic@ionspin.com
  * on 27-May-2020
  */
-interface JsSodiumInterface {
+@JsModule("libsodium-wrappers-sumo")
+@JsNonModule
+external object JsSodiumInterface {
 
-    @JsName("sodium_init")
-    fun sodium_init() : Int
 
     @JsName("crypto_generichash")
     fun crypto_generichash(hashLength: Int, inputMessage: Uint8Array, key: Uint8Array): Uint8Array

--- a/multiplatform-crypto-libsodium-bindings/src/jsMain/kotlin/com/ionspin/kotlin/crypto/JsSodiumLoader.kt
+++ b/multiplatform-crypto-libsodium-bindings/src/jsMain/kotlin/com/ionspin/kotlin/crypto/JsSodiumLoader.kt
@@ -1,11 +1,7 @@
 package ext.libsodium.com.ionspin.kotlin.crypto
 
-import com.ionspin.kotlin.crypto.getSodiumLoaded
-import com.ionspin.kotlin.crypto.setSodiumPointer
-import com.ionspin.kotlin.crypto.sodiumLoaded
-import com.ionspin.kotlin.crypto.sodiumPointer
+import com.ionspin.kotlin.crypto.*
 import ext.libsodium.*
-import kotlin.coroutines.Continuation
 import kotlin.coroutines.suspendCoroutine
 
 /**
@@ -25,18 +21,15 @@ object JsSodiumLoader {
 
     }
 
-    fun storeSodium(promisedSodium: dynamic, continuation: Continuation<Unit>) {
-        setSodiumPointer(promisedSodium)
-        sodiumLoaded = true
-        continuation.resumeWith(Result.success(Unit))
-    }
-
     suspend fun load() = suspendCoroutine<Unit> { continuation ->
         console.log(getSodiumLoaded())
         if (!getSodiumLoaded()) {
-            val libsodiumModule = js("\$module\$libsodium_wrappers_sumo")
             _libsodiumPromise.then<dynamic> {
-                storeSodium(libsodiumModule, continuation)
+                sodium_init()
+                sodiumLoaded = true
+                continuation.resumeWith(Result.success(Unit))
+            }.catch { e ->
+                continuation.resumeWith(Result.failure(e))
             }
         } else {
             continuation.resumeWith(Result.success(Unit))
@@ -46,10 +39,8 @@ object JsSodiumLoader {
     fun loadWithCallback(doneCallback: () -> (Unit)) {
         console.log(getSodiumLoaded())
         if (!getSodiumLoaded()) {
-            val libsodiumModule = js("\$module\$libsodium_wrappers_sumo")
             _libsodiumPromise.then<dynamic> {
-                setSodiumPointer(libsodiumModule)
-                sodiumPointer.sodium_init()
+                sodium_init()
                 sodiumLoaded = true
                 doneCallback.invoke()
             }

--- a/multiplatform-crypto-libsodium-bindings/src/jsMain/kotlin/com/ionspin/kotlin/crypto/LibsodiumInitializer.kt
+++ b/multiplatform-crypto-libsodium-bindings/src/jsMain/kotlin/com/ionspin/kotlin/crypto/LibsodiumInitializer.kt
@@ -2,22 +2,15 @@ package com.ionspin.kotlin.crypto
 
 import ext.libsodium.com.ionspin.kotlin.crypto.JsSodiumInterface
 import ext.libsodium.com.ionspin.kotlin.crypto.JsSodiumLoader
-/* 1.4-M1 has some weirdness with static/objects, or I'm misusing something, not sure */
-lateinit var sodiumPointer : JsSodiumInterface
+
 var sodiumLoaded: Boolean = false
 
-fun getSodium() : JsSodiumInterface = sodiumPointer
-
-//fun getSodiumAdvanced() : JsSodiumAdvancedInterface = js("sodiumPointer.libsodium")
-
-fun setSodiumPointer(jsSodiumInterface: JsSodiumInterface) {
-    js("sodiumPointer = jsSodiumInterface")
-}
+fun getSodium() : JsSodiumInterface = JsSodiumInterface
 
 fun getSodiumLoaded() : Boolean = sodiumLoaded
 
 fun setSodiumLoaded(loaded: Boolean) {
-    js("sodiumLoaded = loaded")
+    sodiumLoaded = loaded
 }
 
 actual object LibsodiumInitializer {

--- a/multiplatform-crypto-libsodium-bindings/src/jsMain/kotlin/libsodium.kt
+++ b/multiplatform-crypto-libsodium-bindings/src/jsMain/kotlin/libsodium.kt
@@ -1,4 +1,4 @@
-@file:JsModule("libsodium-wrappers-sumo")
+@file:JsModule("libsodium-sumo")
 @file:JsNonModule
 package ext.libsodium
 
@@ -14,6 +14,9 @@ import kotlin.js.Promise
 
 @JsName("ready")
 external val _libsodiumPromise : Promise<dynamic>
+
+@JsName("_sodium_init")
+external fun sodium_init() : Int
 
 external fun crypto_generichash(hashLength: Int, inputMessage: Uint8Array) : Uint8Array
 

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -277,6 +277,7 @@ kotlin {
                 dependencies {
                     implementation(kotlin(Deps.Jvm.test))
                     implementation(kotlin(Deps.Jvm.testJUnit))
+                    implementation(Deps.Jvm.coroutinesTest)
                     implementation(kotlin(Deps.Jvm.reflection))
                 }
             }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -185,6 +185,7 @@ kotlin {
                 implementation(kotlin(Deps.Common.test))
                 implementation(Deps.Common.serialization)
                 api(project(":multiplatform-crypto-libsodium-bindings"))
+                implementation(Deps.Common.coroutines)
             }
         }
         val commonTest by getting {
@@ -203,7 +204,6 @@ kotlin {
                 implementation("androidx.constraintlayout:constraintlayout:2.0.2")
                 implementation("com.google.android.material:material:1.3.0-alpha03")
 
-                implementation(Deps.Android.coroutines)
                 implementation(Deps.Android.timber)
 //                implementation("androidx.compose:compose-runtime:$composeDevVersion")
             }
@@ -212,9 +212,7 @@ kotlin {
             dependencies {
                 implementation(kotlin(Deps.Jvm.test))
                 implementation(kotlin(Deps.Jvm.testJUnit))
-                implementation(Deps.Jvm.coroutinesTest)
                 implementation(kotlin(Deps.Jvm.reflection))
-                implementation(Deps.Jvm.coroutinesCore)
             }
         }
 
@@ -255,7 +253,6 @@ kotlin {
             val nativeTest by getting {
                 dependsOn(commonTest)
                 dependencies {
-                    implementation(Deps.Native.coroutines)
                 }
             }
             nativeTest
@@ -263,7 +260,6 @@ kotlin {
             val nativeTest by creating {
                 dependsOn(commonTest)
                 dependencies {
-                    implementation(Deps.Native.coroutines)
                 }
             }
             nativeTest
@@ -287,8 +283,6 @@ kotlin {
             val jsMain by getting {
                 dependencies {
                     implementation(kotlin(Deps.Js.stdLib))
-                    implementation(Deps.Js.coroutines)
-
                 }
             }
             val jsTest by getting {


### PR DESCRIPTION
Use libsodium-sumo module for ready and _sodium_init (libsodium-wrapper-sumo didn't work, ready would hang forever). And use libsodium-wrapper-sumo for JsSodiumInterface

Load JsSodiumInterface as external object

Clean up JsSodiumLoader: remove storeSodium (not needed anymore)
Clean up LibsodiumInitializer: remove sodiumPointer (not needed anymore)

Also, I fixed your coroutine imports to just use common in the sample. (it was causing build issues for me)

Fyi, I tried building with webpack5 and it worked fine. But, didn't make a difference when importing to my project. So, I just left it as it was