### PR TITLE
Fix Equality Check in `XChaCha20EncryptionResult`

### DIFF
--- a/multiplatform-crypto-api/src/commonMain/kotlin/com/ionspin/kotlin/crypto/symmetric/XChaCha20.kt
+++ b/multiplatform-crypto-api/src/commonMain/kotlin/com/ionspin/kotlin/crypto/symmetric/XChaCha20.kt
@@ -25,8 +25,8 @@ data class XChaCha20EncryptionResult(val nonce: UByteArray, val encryptionData: 
 
         other as XChaCha20EncryptionResult
 
-        if (nonce != other.nonce) return false
-        if (encryptionData != other.encryptionData) return false
+        if (!nonce.contentEquals(other.nonce)) return false
+        if (!encryptionData.contentEquals(other.encryptionData)) return false
 
         return true
     }

--- a/multiplatform-crypto-api/src/commonTest/kotlin/com/iospin/kotlin/crypto/symmetric/XChaCha20EncryptionResultTest.kt
+++ b/multiplatform-crypto-api/src/commonTest/kotlin/com/iospin/kotlin/crypto/symmetric/XChaCha20EncryptionResultTest.kt
@@ -1,0 +1,28 @@
+package com.iospin.kotlin.crypto.symmetric
+
+import com.ionspin.kotlin.crypto.symmetric.XChaCha20EncryptionResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class XChaCha20EncryptionResultTest {
+    @Test
+    fun testEquality() {
+        val firstResult = XChaCha20EncryptionResult(
+            nonce = ubyteArrayOf(0x12u, 0x34u, 0x56u),
+            encryptionData = ubyteArrayOf(0x78u, 0x9Au),
+        )
+        val secondResult = XChaCha20EncryptionResult(
+            nonce = ubyteArrayOf(0x12u, 0x34u, 0x56u),
+            encryptionData = ubyteArrayOf(0x78u, 0x9Au),
+        )
+        val differingResult = XChaCha20EncryptionResult(
+            nonce = ubyteArrayOf(0u),
+            encryptionData = ubyteArrayOf(0u),
+        )
+
+        assertEquals(firstResult, secondResult)
+        assertNotEquals(firstResult, differingResult)
+        assertNotEquals(secondResult, differingResult)
+    }
+}


### PR DESCRIPTION
The `XChaCha20EncryptionResult` data class currently implements its own equality check due to the class's byte array members. However, this is using a standard equality check, `==`, rather than checking the array's contents. This will cause two results with the same contained values to return `false` on an equals check.

Confirmed this issue with a unit test, and fixed by changing the implemented method to use `contentEquals` instead.