### PR TITLE
Add custom return code handler for initialization call

### DIFF
--- a/multiplatform-crypto-libsodium-bindings/src/commonMain/kotlin/com.ionspin.kotlin.crypto/GeneralLibsodiumException.kt
+++ b/multiplatform-crypto-libsodium-bindings/src/commonMain/kotlin/com.ionspin.kotlin.crypto/GeneralLibsodiumException.kt
@@ -2,7 +2,7 @@ package com.ionspin.kotlin.crypto
 
 import com.ionspin.kotlin.crypto.util.isLibsodiumSuccessCode
 
-class GeneralLibsodiumException : RuntimeException("Libsodium reported error! Returned value was -1") {
+class GeneralLibsodiumException(message: String) : RuntimeException(message) {
     companion object {
         /**
          * Throws a [GeneralLibsodiumException] if the return code is not
@@ -12,7 +12,7 @@ class GeneralLibsodiumException : RuntimeException("Libsodium reported error! Re
          */
         fun Int.ensureLibsodiumSuccess() {
             if (!isLibsodiumSuccessCode()) {
-                throw GeneralLibsodiumException()
+                throw GeneralLibsodiumException("Libsodium reported error! Returned value was -1")
             }
         }
     }

--- a/multiplatform-crypto-libsodium-bindings/src/commonMain/kotlin/com.ionspin.kotlin.crypto/LibsodiumInitializer.kt
+++ b/multiplatform-crypto-libsodium-bindings/src/commonMain/kotlin/com.ionspin.kotlin.crypto/LibsodiumInitializer.kt
@@ -10,3 +10,21 @@ expect object LibsodiumInitializer {
 
     fun initializeWithCallback(done: () -> (Unit))
 }
+
+/**
+ * Ensures a successful response from the Libsodium init call.
+ *
+ * The init call has a slightly different return pattern, documented as:
+ *
+ *     sodium_init() returns 0 on success, -1 on failure, and 1 if the library had already been initialized.
+ *
+ * This function will throw if anything other than 0 or 1 is returned.
+ */
+internal fun Int.ensureInitSuccess() {
+    when (this) {
+        0, 1 -> {
+            // no-op: both successful responses
+        }
+        else -> throw GeneralLibsodiumException("Libsodium initialization failed with code: $this")
+    }
+}

--- a/multiplatform-crypto-libsodium-bindings/src/jvmMain/kotlin/com/ionspin/kotlin/crypto/LibsodiumInitializer.kt
+++ b/multiplatform-crypto-libsodium-bindings/src/jvmMain/kotlin/com/ionspin/kotlin/crypto/LibsodiumInitializer.kt
@@ -50,13 +50,13 @@ actual object LibsodiumInitializer {
     lateinit var sodiumJna : JnaLibsodiumInterface
     actual suspend fun initialize() {
         sodiumJna = loadLibrary()
-        sodiumJna.sodium_init().ensureLibsodiumSuccess()
+        sodiumJna.sodium_init().ensureInitSuccess()
         isPlatformInitialized = true
     }
 
     actual fun initializeWithCallback(done: () -> Unit) {
         sodiumJna = loadLibrary()
-        sodiumJna.sodium_init().ensureLibsodiumSuccess()
+        sodiumJna.sodium_init().ensureInitSuccess()
         isPlatformInitialized = true
         done()
     }

--- a/multiplatform-crypto-libsodium-bindings/src/nativeMain/kotlin/com/ionspin/kotlin/crypto/LibsodiumInitializer.kt
+++ b/multiplatform-crypto-libsodium-bindings/src/nativeMain/kotlin/com/ionspin/kotlin/crypto/LibsodiumInitializer.kt
@@ -12,7 +12,7 @@ actual object LibsodiumInitializer {
 
     actual suspend fun initialize() {
         if (isPlatformInitialized.compareAndSet(0, 1)) {
-            sodium_init().ensureLibsodiumSuccess()
+            sodium_init().ensureInitSuccess()
         }
 
 
@@ -20,7 +20,7 @@ actual object LibsodiumInitializer {
 
     actual fun initializeWithCallback(done: () -> Unit) {
         if (isPlatformInitialized.compareAndSet(0, 1)) {
-            sodium_init().ensureLibsodiumSuccess()
+            sodium_init().ensureInitSuccess()
         }
         done()
     }


### PR DESCRIPTION
The initialization call returns an additional code `1` if the initialzation has already completed successfully. Added a specific handler for this functionality into the common sources.

@ionspin -- I noticed when dding this code that the javascript implementation doesn't appear to be using the same return code handling as the rest for this call. I left it as-is for now, but is that an oversight or is there something else that handles that?

Fixes #67 